### PR TITLE
ci: let gui/examples/_check.vsh exit with 1 error code, let its output be more informative on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,16 @@ jobs:
         with:
           check-latest: true
 
-      - name: Checkout v-analyzer
+      - name: Checkout the gui module
         uses: actions/checkout@v4
+        with:
+          path: gui
 
       - name: Verify formatting
-        run: v fmt -verify .
+        run: v fmt -verify -inprocess gui/
 
       - name: Check formatting of MD files
-        run: v check-md .
+        run: v check-md gui/
 
       - name: Check compilation of examples
-        run: v examples/_check.vsh
+        run: v gui/examples/_check.vsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,26 +19,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fmt:
+  linting:
     runs-on: ubuntu-latest
-
     steps:
       - name: Install V
         id: install-v
         uses: vlang/setup-v@v1.4
         with:
           check-latest: true
+      - name: Checkout the gui module
+        uses: actions/checkout@v4
+        with:
+          path: gui
+      - name: Verify formatting
+        run: v fmt -verify -inprocess gui/
+      - name: Check formatting of MD files
+        run: v check-md gui/
+      - name: Check compilation of examples
+        run: v gui/examples/_check.vsh
 
+  compiling-with-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install V
+        id: install-v
+        uses: vlang/setup-v@v1.4
+        with:
+          check-latest: true
       - name: Checkout the gui module
         uses: actions/checkout@v4
         with:
           path: gui
 
-      - name: Verify formatting
-        run: v fmt -verify -inprocess gui/
-
-      - name: Check formatting of MD files
-        run: v check-md gui/
-
-      - name: Check compilation of examples
-        run: v gui/examples/_check.vsh
+      - name: Check compilation of examples with -prod
+        run: v gui/examples/_build.vsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   linting:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Install V
         id: install-v
@@ -40,6 +41,7 @@ jobs:
 
   compiling-with-prod:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Install V
         id: install-v
@@ -50,6 +52,5 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: gui
-
       - name: Check compilation of examples with -prod
         run: v gui/examples/_build.vsh

--- a/examples/_check.vsh
+++ b/examples/_check.vsh
@@ -1,23 +1,30 @@
 #!/usr/bin/env -S v
 
-chdir(dir(@FILE))!
 unbuffer_stdout()
 
-dir_files := ls('.') or { [] }
+dir_files := ls(dir(@FILE)) or { [] }.map(join_path_single(dir(@FILE), it))
 files := dir_files.filter(file_ext(it) == '.v').sorted()
 if files.len == 0 {
 	println('no .v files found')
 	return
 }
+mut errors := []string{}
 for i, file in files {
 	p := 'v -check ${file} '
-	print('(${i + 1:02}/${files.len:02}) ${p:-30}')
+	print('(${i + 1:02}/${files.len:02}) ${p:-70}')
 	result := execute('v -check ${file}')
 	if result.exit_code == 0 {
 		println(' ✅')
 	} else {
 		println(' ⭕')
 		println(result.output)
-		return
+		errors << file
 	}
+}
+if errors.len > 0 {
+	println('Encountered ${errors.len} error(s).')
+	for i, efile in errors {
+		println('   error ${i + 1}/${errors.len} for: `v -check ${efile}`')
+	}
+	exit(1)
 }


### PR DESCRIPTION
Previously the CI did run the check script, but it did exit with a 0 code, even when it found errors: 
![image](https://github.com/user-attachments/assets/49b493e8-9c82-4944-ad44-e3d9d85469b0)


With this PR, that is fixed - the gui module is checked out in a subfolder, so V's idiosyncrasy (dependence on the working folder) does not affect it, and the script now correctly exits with a 1 code, which in turn will allow the CI to fail, if there are future problems.

The output of the script becomes more useful for automations like the CI (it will fail, when any of the files it checks fails to compile), and it will make a concise report of the found errors at its end (making it more actionable for humans, without having to scroll up). The reported file paths and commands also now use absolute paths, which makes them easily copy-able and runnable, without having to edit them in any way.
![image](https://github.com/user-attachments/assets/cebafbab-5c33-4a5e-be17-79e67eda1e95)
