### PR TITLE
fix titlebar_dark build with -cc tcc

### DIFF
--- a/titlebar.c.v
+++ b/titlebar.c.v
@@ -4,9 +4,10 @@ import sokol.sapp
 
 $if windows {
 	$if tinyc {
-		$compile_error('tcc does not support linking to dwmapi for now, use `-cc msvc` or `-cc gcc` instead')
+		#include <windows.h>
+	} $else {
+		#include <dwmapi.h>
 	}
-	#include <dwmapi.h>
 	#flag -ldwmapi
 }
 


### PR DESCRIPTION
 Fixed TCC compilation issue. Tested successfully with TCC, GCC, and MSVC on Win7/Win11.