### PR TITLE
reduce leaks in fonts demo

### DIFF
--- a/window.v
+++ b/window.v
@@ -70,7 +70,13 @@ pub:
 	}
 	on_event            fn (e &Event, mut w Window) = fn (_ &Event, mut _ Window) {}
 	samples             u32                         = 2 // MSAA sample count; rounded courners of buttons with 0 and 1 look jagged on linux/windows
-	log_level           log.Level
+	log_level           log.Level = default_log_level()
+}
+
+fn default_log_level() log.Level {
+	tag := $d('gui_window_log_level', 'disabled')
+	res := log.level_from_tag(tag) or { log.Level.disabled }
+	return res
 }
 
 // window creates the application window. See [WindowCfg](#WindowCfg) on how to configure it

--- a/window.v
+++ b/window.v
@@ -70,7 +70,7 @@ pub:
 	}
 	on_event            fn (e &Event, mut w Window) = fn (_ &Event, mut _ Window) {}
 	samples             u32                         = 2 // MSAA sample count; rounded courners of buttons with 0 and 1 look jagged on linux/windows
-	log_level           log.Level = default_log_level()
+	log_level           log.Level                   = default_log_level()
 }
 
 fn default_log_level() log.Level {
@@ -118,6 +118,7 @@ fn frame_fn(mut window Window) {
 	window.lock()
 	window.ui.begin()
 	renderers_draw(window.renderers, window)
+	gc_collect()
 	window.ui.end()
 	sapp.set_mouse_cursor(window.view_state.mouse_cursor)
 	$if trace_update_window_calls ? {
@@ -234,8 +235,6 @@ pub fn (mut window Window) update_view(gen_view fn (&Window) View) {
 	defer { window.unlock() }
 
 	window.view_generator = gen_view
-	unsafe { window.layout.free() }
-	unsafe { window.renderers.free() }
 	window.layout = layout
 	window.renderers = renderers
 	window.ui.refresh_ui()
@@ -259,8 +258,6 @@ pub fn (mut window Window) update_window() {
 	window_rect := window.window_rect()
 	render_layout(mut layout, mut renderers, window.color_background(), window_rect, window)
 
-	unsafe { window.layout.free() }
-	unsafe { window.renderers.free() }
 	window.layout = layout
 	window.renderers = renderers
 	window.ui.refresh_ui()


### PR DESCRIPTION
- **allow for `-d gui_window_log_level=DEBUG fonts.v` without changing the source of the example**
- **force a gc_collect() call after each frame is rendered, but before it is submitted to the GPU**
