### PR TITLE
Make on_enter override on_text_changed in view_input.v

### DIFF
--- a/view_input.v
+++ b/view_input.v
@@ -155,6 +155,8 @@ fn (cfg &InputCfg) on_char_shape(shape &Shape, mut event Event, mut w Window) {
 				cr_char, lf_char {
 					if cfg.on_enter != unsafe { nil } {
 						cfg.on_enter(cfg, mut event, w)
+						event.is_handled = true
+						return
 					} else {
 						if cfg.mode != .single_line {
 							text = cfg.insert('\n', mut w) or {


### PR DESCRIPTION
When the on_enter event is handled by an application-defined callback, the on_text_changed callback should not be called as this overrides any text changes occurred in the on_enter callback.

E.g.
When pressing enter to send a message, the input field should be cleared after. Doing so in the on_enter callback would result in on_text_changed being called immediately after and reinstating the original text, overriding the cleared input.