### PR TITLE
fix placeholder masked if text_is_password is true

### DIFF
--- a/render.v
+++ b/render.v
@@ -315,7 +315,7 @@ fn render_text(mut shape Shape, mut renderers []Renderer, clip DrawClip, window 
 		// Cull any renderers outside of clip/context region.
 		if rects_overlap(clip, draw_rect) && color != color_transparent {
 			mut lnl := line.replace('\n', '')
-			if shape.text_is_password {
+			if shape.text_is_password && !shape.text_is_placeholder {
 				// replace with '*'s
 				lnl = '*'.repeat(utf8_str_visible_length(lnl))
 			}

--- a/shape.v
+++ b/shape.v
@@ -36,15 +36,16 @@ pub mut:
 	sizing     Sizing
 	spacing    f32
 	// -- text ---
-	text             string
-	text_lines       []string
-	text_style       TextStyle
-	text_mode        TextMode
-	text_is_password bool
-	text_sel_beg     u32
-	text_sel_end     u32
-	text_tab_size    u32 = 4
-	text_spans       datatypes.LinkedList[TextSpan] // rich text format spans
+	text                string
+	text_lines          []string
+	text_style          TextStyle
+	text_mode           TextMode
+	text_is_password    bool
+	text_is_placeholder bool
+	text_sel_beg        u32
+	text_sel_end        u32
+	text_tab_size       u32 = 4
+	text_spans          datatypes.LinkedList[TextSpan] // rich text format spans
 	// --- image ---
 	image_name string // filename of image
 	// --- float ---

--- a/view_text.v
+++ b/view_text.v
@@ -65,6 +65,7 @@ fn (t &TextView) generate(mut window Window) Layout {
 			sizing:              t.sizing
 			text:                t.text
 			text_is_password:    t.is_password
+			text_is_placeholder: t.placeholder_active
 			text_lines:          lines
 			text_mode:           t.mode
 			text_style:          t.text_style


### PR DESCRIPTION
I noticed that input placeholders are masked (replaced with '*'s) when `is_password` is set to true. This is due to the lack of a way in `render_text` to determine if it's a placeholder. This PR adds the `text_is_placeholder` field to the `Shape` struct and modifies `render_text` to check whether the text is a placeholder.